### PR TITLE
Potential fix for code scanning alert no. 35: Clear-text logging of sensitive information

### DIFF
--- a/services/mail.js
+++ b/services/mail.js
@@ -43,7 +43,7 @@ const mailer = {
         const verify = user.resetPasswordInfo.verify;
         const URL = user.resetPasswordInfo.URL;
         const link = `http://${URL}?l=${lookup}&v=${verify}`;
-        debug(link);
+        debug('Reset password link generated');
         const textFile = path.join(__dirname, '../resources/emails/resetPassword_text.ejs');
         ejs.renderFile(textFile, { name, link }, (err, text) => {
             if (err) return debug(err);


### PR DESCRIPTION
Potential fix for [https://github.com/aboudzz/lighty/security/code-scanning/35](https://github.com/aboudzz/lighty/security/code-scanning/35)

To fix the problem, we should avoid logging sensitive information such as the `link` variable directly. Instead, we can log a generic message indicating that a reset password link was generated without including the actual link. This way, we maintain the ability to debug the process without exposing sensitive data.

- Replace the logging of the `link` variable with a generic message.
- Ensure that the changes are made in the `sendResetPassword` function in the `services/mail.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
